### PR TITLE
BinaryDeserializer: Improve performance when reading wrong type

### DIFF
--- a/Yuzu/BinaryDeserializer.cs
+++ b/Yuzu/BinaryDeserializer.cs
@@ -475,11 +475,17 @@ namespace Yuzu.Binary
 			def.ReadFields(this, def, obj);
 		}
 
-		private void CheckAssignable(Type dest, Type src, object value)
+		private object MakeAndCheckAssignable<T>(ReaderClassDef def)
 		{
-			if (!dest.IsAssignableFrom(src))
-				throw Error("Unable to assign type \"{0}\" to \"{1}\"",
-					src == typeof(YuzuUnknown) ? ((YuzuUnknownBinary)value).ClassTag : src.ToString(), dest);
+			var srcType = def.Meta.Type;
+			var srcIsUnknown = srcType == typeof(YuzuUnknown);
+			var dstType = typeof(T);
+			if (!srcIsUnknown && !dstType.IsAssignableFrom(srcType))
+					throw Error("Unable to assign type \"{0}\" to \"{1}\"", srcType.ToString(), dstType);
+			var result = def.Make?.Invoke(this, def);
+			if (srcIsUnknown && !dstType.IsInstanceOfType(result))
+					throw Error("Unable to assign type \"{0}\" to \"{1}\"", ((YuzuUnknownBinary)result).ClassTag, dstType);
+			return result;
 		}
 
 		protected object ReadObject<T>() where T : class
@@ -488,8 +494,7 @@ namespace Yuzu.Binary
 			if (classId == 0)
 				return null;
 			var def = GetClassDef(classId);
-			var result = def.Make?.Invoke(this, def);
-			CheckAssignable(typeof(T), def.Meta.Type, result);
+			var result = MakeAndCheckAssignable<T>(def);
 			if (result == null) {
 				result = def.Meta.Factory();
 				def.ReadFields(this, def, result);
@@ -523,8 +528,7 @@ namespace Yuzu.Binary
 			if (classId == 0)
 				return null;
 			var def = GetClassDef(classId);
-			var result = def.Make?.Invoke(this, def);
-			CheckAssignable(typeof(T), def.Meta.Type, result);
+			var result = MakeAndCheckAssignable<T>(def);
 			if (result == null) {
 				result = def.Meta.Factory();
 				def.ReadFields(this, def, result);
@@ -538,9 +542,7 @@ namespace Yuzu.Binary
 			if (classId == 0)
 				return;
 			var def = GetClassDef(classId);
-
-			var result = def.Make?.Invoke(this, def);
-			CheckAssignable(typeof(T), def.Meta.Type, result);
+			var result = MakeAndCheckAssignable<T>(def);
 			if (result == null) {
 				result = def.Meta.Factory();
 				def.ReadFields(this, def, result);

--- a/Yuzu/YuzuTest/TestBinary.cs
+++ b/Yuzu/YuzuTest/TestBinary.cs
@@ -2255,6 +2255,9 @@ namespace YuzuTest.Binary
 				"20 03 00 " + XS(typeof(SampleList)) + " 01 00 " + XS("E", RoughType.Sequence) + " 05 01 00" +
 				" 00 00 00 00 00 00"
 			)), "List");
+			XAssert.Throws<YuzuException>(() => bd.FromBytes<Sample1>(SX(
+				"20 03 00 " + XS(typeof(YuzuTest.Sample2)) + " 02 00 " + XS("X") + " 05 " + XS("Y") +  " 10"
+			)), "YuzuTest.Sample2");
 
 		}
 


### PR DESCRIPTION
When trying to deserialize a type which is not assignable from serialized type (either by mistake or on purpose which is legit) Yuzu was deserializing whole stream for the purpose of providing a descriptive exception text when deserializing from YuzuUnknown. 