### PR TITLE
fix mono crash: https://github.com/xamarin/xamarin-android/issues/5127

### DIFF
--- a/Yuzu/BinaryCommon.cs
+++ b/Yuzu/BinaryCommon.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 using Yuzu.Metadata;
@@ -60,6 +60,7 @@ namespace Yuzu.Binary
 
 		public static bool IsRecord(this Type t)
 		{
+			// TODO: when type.IsArray is true type.IsClass is also true, which seems to be a bug in this method
 			return t.IsClass || t.IsInterface || Utils.IsStruct(t);
 		}
 	}

--- a/Yuzu/BinaryDeserializer.cs
+++ b/Yuzu/BinaryDeserializer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Reflection;
 
@@ -76,7 +76,7 @@ namespace Yuzu.Binary
 		{
 			if (expectedType.IsEnum)
 				return ReadCompatibleType(Enum.GetUnderlyingType(expectedType));
-			if (expectedType.IsRecord() && !expectedType.Namespace.StartsWith("System")) {
+			if (!expectedType.IsArray && expectedType.IsRecord() && (!expectedType.Namespace?.StartsWith("System") ?? true)) {
 				var sg = Meta.Get(expectedType, Options).Surrogate;
 				if (sg.SurrogateType != null && sg.FuncFrom != null)
 					return ReadCompatibleType(sg.SurrogateType);


### PR DESCRIPTION
fix crash related to mono returning null for Type.Namespace of array of nested type